### PR TITLE
new(core): avoid storing contexts in ctxmap; instead, use thread specific storage

### DIFF
--- a/Lib/core/ctx.c
+++ b/Lib/core/ctx.c
@@ -243,7 +243,7 @@ static int recv_events(m_ctx_t *c, int timeout) {
              * a m_mod_deregister() call by user callback
              * invalidates our pointer.
              */
-            m_mod_t *mod = m_mem_ref(p->mod);
+            m_mod_t *mod = p->mod;
             evt_priv_t *evt = new_evt(p);
             m_evt_t *msg = NULL;
             if (evt) {
@@ -293,7 +293,6 @@ static int recv_events(m_ctx_t *c, int timeout) {
                  */
                 m_mem_unref(evt);
             }
-            m_mem_unref(mod);
         } else {
             /* Forward error to below handling code */
             err = EAGAIN;
@@ -398,9 +397,12 @@ void inline ctx_logger(const m_ctx_t *c, const m_mod_t *mod, const char *fmt, ..
 
 /** Public API **/
 
-_public_ m_ctx_t *m_ctx_ref(void) {
+_public_ m_ctx_t *m_ctx(void) {
     m_ctx_t *c = pthread_getspecific(key);
-    return m_mem_ref(c);
+    if (c->curr_mod) {
+        M_RET_ASSERT(!(c->curr_mod->flags & M_MOD_DENY_CTX), NULL);
+    }
+    return c;
 }
 
 _public_ int m_ctx_register(const char *ctx_name, OUT m_ctx_t **c, m_ctx_flags flags, const void *userdata) {

--- a/Lib/core/ctx.c
+++ b/Lib/core/ctx.c
@@ -399,7 +399,7 @@ void inline ctx_logger(const m_ctx_t *c, const m_mod_t *mod, const char *fmt, ..
 
 _public_ m_ctx_t *m_ctx(void) {
     m_ctx_t *c = pthread_getspecific(key);
-    if (c->curr_mod) {
+    if (c && c->curr_mod) {
         M_RET_ASSERT(!(c->curr_mod->flags & M_MOD_DENY_CTX), NULL);
     }
     return c;

--- a/Lib/core/ctx.h
+++ b/Lib/core/ctx.h
@@ -4,19 +4,15 @@
 #include "public/module/structs/map.h"
 #include "public/module/thpool/thpool.h"
 #include "globals.h"
+#include "src.h"
 
 #define M_CTX_DEFAULT_EVENTS    64
 
-// #define M_CTX() m_ctx_t *c = m_ctx();
-// 
-// #define M_CTX_ASSERT(c) \
-// M_CTX(); \
-// M_RET_ASSERT(c, -EPIPE); \
-// M_RET_ASSERT(c->state != M_CTX_ZOMBIE, -EACCES)
+#define M_CTX() m_ctx_t *c = m_ctx();
 
-#define M_CTX_ASSERT(c) \
-    M_PARAM_ASSERT(c); \
-    M_RET_ASSERT(c->state != M_CTX_ZOMBIE, -EACCES)
+#define M_CTX_ASSERT() \
+    M_CTX(); \
+    M_RET_ASSERT(c, -EPIPE)
 
 typedef struct {
     void *data;                             // Context's poll priv data (depends upon poll_plugin)
@@ -34,7 +30,6 @@ typedef struct {
 typedef enum {
     M_CTX_IDLE,
     M_CTX_LOOPING,
-    M_CTX_ZOMBIE,
 } m_ctx_states;
 
 typedef struct {
@@ -67,4 +62,5 @@ struct _ctx {
     CONST const void *userdata;             // Context's user defined data
 };
 
+m_ctx_t *m_ctx(void);
 void ctx_logger(const m_ctx_t *c, const m_mod_t *mod, const char *fmt, ...);

--- a/Lib/core/ctx.h
+++ b/Lib/core/ctx.h
@@ -59,6 +59,4 @@ struct _ctx {
     CONST const void *userdata;             // Context's user defined data
 };
 
-int ctx_new(const char *ctx_name, m_ctx_t **c, m_ctx_flags flags, const void *userdata);
-m_ctx_t *check_ctx(const char *ctx_name);
 void ctx_logger(const m_ctx_t *c, const m_mod_t *mod, const char *fmt, ...);

--- a/Lib/core/ctx.h
+++ b/Lib/core/ctx.h
@@ -50,6 +50,7 @@ struct _ctx {
     bool finalized;                         // Whether the context is finalized, ie: no more modules can be registered
     m_log_cb logger;                        // Context's log callback
     m_map_t *modules;                       // Context's modules
+    m_mod_t *curr_mod;                      // Current module's being processed. NULL when we are outside of any module.
     poll_priv_t ppriv;                      // Priv data for poll_plugin implementation
     CONST m_ctx_flags flags;                // Context's flags
     void *fs;                               // FS context handler. Null if unsupported

--- a/Lib/core/ctx.h
+++ b/Lib/core/ctx.h
@@ -7,6 +7,13 @@
 
 #define M_CTX_DEFAULT_EVENTS    64
 
+// #define M_CTX() m_ctx_t *c = m_ctx();
+// 
+// #define M_CTX_ASSERT(c) \
+// M_CTX(); \
+// M_RET_ASSERT(c, -EPIPE); \
+// M_RET_ASSERT(c->state != M_CTX_ZOMBIE, -EACCES)
+
 #define M_CTX_ASSERT(c) \
     M_PARAM_ASSERT(c); \
     M_RET_ASSERT(c->state != M_CTX_ZOMBIE, -EACCES)

--- a/Lib/core/evts.c
+++ b/Lib/core/evts.c
@@ -85,7 +85,7 @@ _public_ ssize_t m_mod_unstash(m_mod_t *mod, size_t len) {
         }
         m_evt_t *evt = m_itr_get(m_itr);
         /*
-         * Here evt has 1 ref; run_pubsub_cb() would drop it
+         * Here evt has 1 ref; call_pubsub_cb() would drop it
          * thus invalidating ptr.
          * But m_itr_rm() still needs ptrs!
          * Keep evts alive.

--- a/Lib/core/evts.c
+++ b/Lib/core/evts.c
@@ -26,16 +26,6 @@ evt_priv_t *new_evt(ev_src_t *src) {
 
 /** Public API **/
 
-/* Must be unref through m_mem_unref() */
-_public_ m_mod_t *m_mod_ref(const m_mod_t *mod, const char *name) {
-    M_RET_ASSERT(mod, NULL);
-    M_RET_ASSERT(name, NULL);
-    M_MOD_CTX(mod);
-
-    m_mod_t *m = m_map_get(c->modules, name);
-    return m_mem_ref(m);
-}
-
 _public_ int m_mod_become(m_mod_t *mod, m_evt_cb new_on_evt) {
     M_PARAM_ASSERT(new_on_evt);
     M_MOD_ASSERT_STATE(mod, M_MOD_RUNNING);

--- a/Lib/core/evts.c
+++ b/Lib/core/evts.c
@@ -45,7 +45,7 @@ _public_ int m_mod_unbecome(m_mod_t *mod) {
 }
 
 _public_ int m_mod_stash(m_mod_t *mod, const m_evt_t *evt) {
-    M_MOD_ASSERT(mod);
+    M_MOD_ASSERT_STATE(mod, M_MOD_RUNNING);
     M_PARAM_ASSERT(evt);
     M_MOD_CONSUME_TOKEN(mod);
     
@@ -61,7 +61,7 @@ _public_ int m_mod_stash(m_mod_t *mod, const m_evt_t *evt) {
 }
 
 _public_ ssize_t m_mod_unstash(m_mod_t *mod, size_t len) {
-    M_MOD_ASSERT(mod);
+    M_MOD_ASSERT_STATE(mod, M_MOD_RUNNING);
     M_PARAM_ASSERT(len > 0);
     M_MOD_CONSUME_TOKEN(mod);
 

--- a/Lib/core/fs/fs.c
+++ b/Lib/core/fs/fs.c
@@ -412,8 +412,8 @@ int fs_destroy(m_ctx_t *c) {
 
 /** Public API **/
 
-_public_ int m_ctx_fs_set_root(m_ctx_t *c, const char *path) {
-    M_CTX_ASSERT(c);
+_public_ int m_ctx_fs_set_root(const char *path) {
+    M_CTX_ASSERT();
     M_RET_ASSERT(c->state == M_CTX_IDLE, -EPERM);
     M_PARAM_ASSERT(str_not_empty(path));
     FS_PRIV();
@@ -423,8 +423,8 @@ _public_ int m_ctx_fs_set_root(m_ctx_t *c, const char *path) {
     return 0;
 }
 
-_public_ int m_ctx_fs_set_ops(m_ctx_t *c, const struct fuse_operations *ops) {
-    M_CTX_ASSERT(c);
+_public_ int m_ctx_fs_set_ops(const struct fuse_operations *ops) {
+    M_CTX_ASSERT();
     M_RET_ASSERT(c->state == M_CTX_IDLE, -EPERM);
     M_PARAM_ASSERT(ops);
     FS_PRIV();

--- a/Lib/core/fs/fs.h
+++ b/Lib/core/fs/fs.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "public/module/mod.h"
-#include "public/module/ctx.h"
+#include "ctx.h"
 
 int fs_create(m_ctx_t *c);
 int fs_start(m_ctx_t *c);

--- a/Lib/core/main.c
+++ b/Lib/core/main.c
@@ -7,10 +7,6 @@
  * Code related to main library ctor/dtor + main() symbol. *
  ***********************************************************/
 
-_public_ _m_ctor0_ _weak_ void m_on_boot(void) {
-    M_DEBUG("Booting libmodule.\n");
-}
-
 _public_ _weak_ void m_ctx_pre_loop(m_ctx_t *c, int argc, char *argv[]) {
     M_DEBUG("Pre-looping libmodule easy API.\n");
 }

--- a/Lib/core/main.c
+++ b/Lib/core/main.c
@@ -40,14 +40,6 @@ _public_ _weak_ int main(int argc, char *argv[]) {
     return ret;
 }
 
-static _m_ctor1_ void libmodule_init(void) {
-    M_INFO("Initializing libmodule %d.%d.%d.\n", LIBMODULE_VERSION_MAJ, LIBMODULE_VERSION_MIN, LIBMODULE_VERSION_PAT);
-}
-
-static _m_dtor0_ void libmodule_deinit(void) {
-    M_INFO("Destroying libmodule.\n");
-}
-
 void mem_dtor(void *src) {
     m_mem_unref(src);
 }

--- a/Lib/core/main.c
+++ b/Lib/core/main.c
@@ -32,7 +32,6 @@ _public_ _weak_ int main(int argc, char *argv[]) {
     const int ret = m_ctx_loop(c);
     m_ctx_post_loop(c, argc, argv);
     m_ctx_deregister(&c); // default_ctx may be NULL here, if eg: all modules where deregistered. We don't care
-    m_mem_unrefp((void **)&c);
     return ret;
 }
 

--- a/Lib/core/main.c
+++ b/Lib/core/main.c
@@ -7,11 +7,11 @@
  * Code related to main library ctor/dtor + main() symbol. *
  ***********************************************************/
 
-_public_ _weak_ void m_ctx_pre_loop(m_ctx_t *c, int argc, char *argv[]) {
+_public_ _weak_ void m_ctx_pre_loop(int argc, char *argv[]) {
     M_DEBUG("Pre-looping libmodule easy API.\n");
 }
 
-_public_ _weak_ void m_ctx_post_loop(m_ctx_t *c, int argc, char *argv[]) {
+_public_ _weak_ void m_ctx_post_loop(int argc, char *argv[]) {
     M_DEBUG("Post-looping libmodule easy API.\n");
 }
 
@@ -23,15 +23,10 @@ _public_ _weak_ void m_ctx_post_loop(m_ctx_t *c, int argc, char *argv[]) {
  * All it does is looping on default ctx.
  */
 _public_ _weak_ int main(int argc, char *argv[]) {
-    m_ctx_t *c = m_ctx();
-    if (!c) {
-        M_ERR("No context available.\n");
-        return EXIT_FAILURE;
-    }
-    m_ctx_pre_loop(c, argc, argv);
-    const int ret = m_ctx_loop(c);
-    m_ctx_post_loop(c, argc, argv);
-    m_ctx_deregister(&c); // default_ctx may be NULL here, if eg: all modules where deregistered. We don't care
+    m_ctx_pre_loop(argc, argv);
+    const int ret = m_ctx_loop();
+    m_ctx_post_loop(argc, argv);
+    m_ctx_deregister(); // default_ctx may be NULL here, if eg: all modules where deregistered. We don't care
     return ret;
 }
 

--- a/Lib/core/main.c
+++ b/Lib/core/main.c
@@ -27,7 +27,7 @@ _public_ _weak_ void m_ctx_post_loop(m_ctx_t *c, int argc, char *argv[]) {
  * All it does is looping on default ctx.
  */
 _public_ _weak_ int main(int argc, char *argv[]) {
-    m_ctx_t *c = m_ctx_ref();
+    m_ctx_t *c = m_ctx();
     if (!c) {
         M_ERR("No context available.\n");
         return EXIT_FAILURE;

--- a/Lib/core/mod.c
+++ b/Lib/core/mod.c
@@ -132,6 +132,7 @@ static int optional_hook(m_mod_t *mod, enum mod_hook req_hook) {
     int ret;
 
     M_MEM_LOCK(mod, {
+        mod->ctx->curr_mod = mod;
         switch (req_hook) {
         case MOD_START:
             if (mod->hook.on_start) {
@@ -151,7 +152,8 @@ static int optional_hook(m_mod_t *mod, enum mod_hook req_hook) {
         default:
             break;
         }
-        
+        mod->ctx->curr_mod = NULL;
+
         ret = bool_ret ? 0 : -1;
         if (m_mod_is(mod, M_MOD_ZOMBIE)) {
             // m_mod_deregister was called

--- a/Lib/core/mod.c
+++ b/Lib/core/mod.c
@@ -81,7 +81,7 @@ static int init_pubsub_fd(m_mod_t *mod) {
 
 static int manage_srcs(m_mod_t *mod, m_ctx_t *c, int flag, bool stop) {
     int ret = 0;
-    
+
     for (int i = 0; i < M_SRC_TYPE_END; i++) {
         m_itr_foreach(mod->srcs[i], {
             ev_src_t *t = m_itr_get(m_itr);
@@ -95,7 +95,7 @@ static int manage_srcs(m_mod_t *mod, m_ctx_t *c, int flag, bool stop) {
                 ret = m_itr_rm(m_itr);
             } else {
                 ret = poll_set_new_evt(&c->ppriv, t, flag);
-                
+
                 /* For type task: create task thread now */
                 if (ret == 0 && t->type == M_SRC_TYPE_TASK && flag == ADD) {
                     ret = start_task(c, t);

--- a/Lib/core/mod.c
+++ b/Lib/core/mod.c
@@ -328,7 +328,7 @@ int mod_deregister(m_mod_t **mod, bool from_user) {
              * it has no more modules in it and is not a persistent ctx
              */
             if (c->state == M_CTX_IDLE && m_map_len(c->modules) == 0 && !(c->flags & M_CTX_PERSIST)) {
-                ret = m_ctx_deregister(&c);
+                ret = m_ctx_deregister();
             }
         }
     });
@@ -429,12 +429,12 @@ void mod_dump(const m_mod_t *mod, bool log_mod, const char *indent) {
 
 /** Public API **/
 
-_public_ int m_mod_register(const char *name, m_ctx_t *c, m_mod_t **mod_ref, const m_mod_hook_t *hook,
+_public_ int m_mod_register(const char *name, m_mod_t **mod_ref, const m_mod_hook_t *hook,
                             m_mod_flags flags, const void *userdata) {
     M_PARAM_ASSERT(str_not_empty(name));
     /* Mandatory callback if hook is passed */
     M_PARAM_ASSERT(!hook || hook->on_evt);
-    M_PARAM_ASSERT(c);
+    M_CTX_ASSERT();
     
     if (c->finalized) {
         return -EPERM;

--- a/Lib/core/mod.c
+++ b/Lib/core/mod.c
@@ -696,3 +696,11 @@ _public_ int m_mod_bind(m_mod_t *mod, m_mod_t *ref) {
     
     return m_list_insert(ref->bound_mods, m_mem_ref(mod));
 }
+
+_public_ m_mod_t *m_mod_lookup(const m_mod_t *mod, const char *name) {
+    M_RET_ASSERT(mod, NULL);
+    M_RET_ASSERT(name, NULL);
+    M_MOD_CTX(mod);
+    
+    return m_map_get(c->modules, name);
+}

--- a/Lib/core/mod.c
+++ b/Lib/core/mod.c
@@ -589,15 +589,14 @@ _public_ __attribute__((format (printf, 2, 3))) int m_mod_log(const m_mod_t *mod
 
 _public_ const void *m_mod_userdata(const m_mod_t *mod) {
     M_RET_ASSERT(mod, NULL);
-    M_RET_ASSERT(!m_mod_is(mod, M_MOD_ZOMBIE), NULL);
-    
+
     return mod->userdata;
 }
 
-_public_ const char *m_mod_name(const m_mod_t *mod_self) {
-    M_RET_ASSERT(mod_self, NULL);
+_public_ const char *m_mod_name(const m_mod_t *mod) {
+    M_RET_ASSERT(mod, NULL);
 
-    return mod_self->name;
+    return mod->name;
 }
 
 /** Module state getters **/
@@ -616,7 +615,7 @@ _public_ m_mod_states m_mod_state(const m_mod_t *mod) {
 
 _public_ int m_mod_dump(const m_mod_t *mod) {
     M_MOD_ASSERT(mod);
-    
+
     mod_dump(mod, true, "");
     return 0;
 }
@@ -693,6 +692,7 @@ _public_ m_mod_t *m_mod_lookup(const m_mod_t *mod, const char *name) {
     M_RET_ASSERT(mod, NULL);
     M_RET_ASSERT(name, NULL);
     M_MOD_CTX(mod);
-    
+    M_RET_ASSERT(c == m_ctx(), NULL);
+
     return m_map_get(c->modules, name);
 }

--- a/Lib/core/mod.c
+++ b/Lib/core/mod.c
@@ -635,14 +635,6 @@ _public_ int m_mod_stats(const m_mod_t *mod, m_mod_stats_t *stats) {
     return 0;
 }
 
-_public_ m_ctx_t *m_mod_ctx(const m_mod_t *mod) {
-    M_RET_ASSERT(mod, NULL);
-    M_RET_ASSERT(!m_mod_is(mod, M_MOD_ZOMBIE), NULL);
-    M_RET_ASSERT(!(mod->flags & M_MOD_DENY_CTX), NULL);
-
-    return mod->ctx;
-}
-
 /** Module state setters **/
 
 #define M_MOD_BOUND(fn) \

--- a/Lib/core/mod.h
+++ b/Lib/core/mod.h
@@ -3,11 +3,13 @@
 #include "public/module/mod.h"
 #include "globals.h"
 
-#define M_MOD_CTX(mod)    m_ctx_t *c = mod->ctx;
+#define M_MOD_CTX(mod) \
+    m_ctx_t *c = mod->ctx;
 
 #define M_MOD_ASSERT(mod) \
     M_PARAM_ASSERT(mod); \
-    M_RET_ASSERT(!m_mod_is(mod, M_MOD_ZOMBIE), -EACCES)
+    M_RET_ASSERT(!m_mod_is(mod, M_MOD_ZOMBIE), -EACCES); \
+    M_RET_ASSERT(mod->ctx == m_ctx(), -EPERM)
 
 #define M_MOD_ASSERT_PERM(mod, perm) \
     M_MOD_ASSERT(mod); \

--- a/Lib/core/mod.h
+++ b/Lib/core/mod.h
@@ -43,6 +43,9 @@ typedef struct {
     m_src_tmr_t timer;
 } mod_tb_t;
 
+/* Forward declare ctx handler */
+typedef struct _ctx m_ctx_t;
+
 /* Struct that holds data for each module */
 /*
  * MEM-REFS for mod:
@@ -70,7 +73,7 @@ struct _mod {
     m_map_t *subscriptions;                 // module's subscriptions (map of ev_src_t*)
     m_queue_t *stashed;                     // module's stashed messages
     m_list_t *bound_mods;                   // modules that are bound to this module's state
-    CONST m_ctx_t *ctx;                     // Module's ctx
+    CONST m_ctx_t *ctx;                     // Module's ctx -> even if ctx is threadspecific data, we need to know the context a module was registered into, to avoid user passing modules around to another thread/context
 };
 
 int evaluate_module(void *data, const char *key, void *value);

--- a/Lib/core/public/module/cmn.h.in
+++ b/Lib/core/public/module/cmn.h.in
@@ -9,33 +9,15 @@
 #include <stdarg.h>
 #include <sys/types.h>
 
-#define LIBMODULE_VERSION_MAJ @PROJECT_VERSION_MAJOR@
-#define LIBMODULE_VERSION_MIN @PROJECT_VERSION_MINOR@
-#define LIBMODULE_VERSION_PAT @PROJECT_VERSION_PATCH@
+#define LIBMODULE_VERSION_MAJ 6
+#define LIBMODULE_VERSION_MIN 0
+#define LIBMODULE_VERSION_PAT 0
 
 /*
  * Function parameters that actually are
  * output values, are marked by this macro.
  */
 #define OUT
-
-/*
- * ctors order:
- * 0) global m_pre_start(), useful to set your own memhook if desired
- * 1) internal libmodule_init()
- * 2) each m_mod_on_boot() (only mod_easy API)
- * 3) each m_mod_ctor() (only mod_easy API)
- *
- * dtors order:
- * 1) each m_mod_dtor() (only mod_easy API)
- * 0) internal libmodule_deinit()
- */
-#define _m_ctor0_         __attribute__((constructor (110)))
-#define _m_ctor1_         __attribute__((constructor (111)))
-#define _m_ctor2_         __attribute__((constructor (113)))
-#define _m_ctor3_         __attribute__((constructor (114)))
-#define _m_dtor0_         __attribute__((destructor (110)))
-#define _m_dtor1_         __attribute__((destructor (111)))
 
 /** Structs types **/
 
@@ -44,7 +26,7 @@ typedef struct _mod m_mod_t;
 typedef struct _ctx m_ctx_t;
 
 /*
- * Common to any context; set this in m_pre_start(),
+ * Common to any context; set this in m_on_boot(),
  * ie: before library is inited and internal structures allocated
  */
 int m_set_memhook(  void *(*_malloc)(size_t),

--- a/Lib/core/public/module/cmn.h.in
+++ b/Lib/core/public/module/cmn.h.in
@@ -21,9 +21,8 @@
 
 /** Structs types **/
 
-/* Incomplete structure declaration to mod and ctx handlers */
+/* Incomplete structure declaration to mod handler */
 typedef struct _mod m_mod_t;
-typedef struct _ctx m_ctx_t;
 
 /*
  * Common to any context; set this in m_on_boot(),

--- a/Lib/core/public/module/ctx.h.in
+++ b/Lib/core/public/module/ctx.h.in
@@ -25,32 +25,29 @@ typedef struct {
 /* Logger callback */
 typedef void (*m_log_cb)(const m_mod_t *ref, const char *fmt, va_list args);
 
-/* Returns ctx associated with current thread, if any. */
-m_ctx_t *m_ctx(void);
-
 /* Context interface functions */
-int m_ctx_register(const char *ctx_name, OUT m_ctx_t **c, m_ctx_flags flags, const void *userdata);
-int m_ctx_deregister(OUT m_ctx_t **c);
+int m_ctx_register(const char *ctx_name, m_ctx_flags flags, const void *userdata);
+int m_ctx_deregister(void);
 
-int m_ctx_set_logger(m_ctx_t *c, m_log_cb logger);
-int m_ctx_loop(m_ctx_t *c);
-int m_ctx_quit(m_ctx_t *c, uint8_t quit_code);
+int m_ctx_set_logger( m_log_cb logger);
+int m_ctx_loop(void);
+int m_ctx_quit(uint8_t quit_code);
 
-int m_ctx_fd(const m_ctx_t *c);
+int m_ctx_fd(void);
 
-int m_ctx_dispatch(m_ctx_t *c);
+int m_ctx_dispatch(void);
 
-int m_ctx_dump(const m_ctx_t *c);
-int m_ctx_stats(const m_ctx_t *c, OUT m_ctx_stats_t *stats);
+int m_ctx_dump(void);
+int m_ctx_stats(OUT m_ctx_stats_t *stats);
 
-const char *m_ctx_name(const m_ctx_t *c);
-const void *m_ctx_userdata(const m_ctx_t *c);
+const char *m_ctx_name(void);
+const void *m_ctx_userdata(void);
 
-ssize_t m_ctx_len(const m_ctx_t *c);
+ssize_t m_ctx_len(void);
 
-int m_ctx_finalize(m_ctx_t *c);
+int m_ctx_finalize(void);
 
-int m_ctx_set_tick(m_ctx_t *c, uint64_t ns);
+int m_ctx_set_tick(uint64_t ns);
 
 /* FuseFS api */
 @M_CTX_HAS_FS@
@@ -69,7 +66,7 @@ enum {
     M_MOD_FS_STATS               = _IOR(LIBMODULE_MAGIC, 1, m_mod_stats_t),
 };
 
-int m_ctx_fs_set_root(m_ctx_t *c, const char *path);
-int m_ctx_fs_set_ops(m_ctx_t *c, const struct fuse_operations *ops);
+int m_ctx_fs_set_root(const char *path);
+int m_ctx_fs_set_ops(const struct fuse_operations *ops);
 
 #endif

--- a/Lib/core/public/module/ctx.h.in
+++ b/Lib/core/public/module/ctx.h.in
@@ -25,8 +25,8 @@ typedef struct {
 /* Logger callback */
 typedef void (*m_log_cb)(const m_mod_t *ref, const char *fmt, va_list args);
 
-/* Returns ctx associated with current thread, if any. It increments ctx ref counter. */
-m_ctx_t *m_ctx_ref(void);
+/* Returns ctx associated with current thread, if any. */
+m_ctx_t *m_ctx(void);
 
 /* Context interface functions */
 int m_ctx_register(const char *ctx_name, OUT m_ctx_t **c, m_ctx_flags flags, const void *userdata);

--- a/Lib/core/public/module/ctx.h.in
+++ b/Lib/core/public/module/ctx.h.in
@@ -25,8 +25,8 @@ typedef struct {
 /* Logger callback */
 typedef void (*m_log_cb)(const m_mod_t *ref, const char *fmt, va_list args);
 
-/* Returns default ctx if registered */
-m_ctx_t *m_ctx_ref(const char *ctx_name);
+/* Returns ctx associated with current thread, if any. It increments ctx ref counter. */
+m_ctx_t *m_ctx_ref(void);
 
 /* Context interface functions */
 int m_ctx_register(const char *ctx_name, OUT m_ctx_t **c, m_ctx_flags flags, const void *userdata);

--- a/Lib/core/public/module/mod.h
+++ b/Lib/core/public/module/mod.h
@@ -205,9 +205,6 @@ int m_mod_register(const char *name, m_ctx_t *c, OUT m_mod_t **mod_ref, const m_
                    m_mod_flags flags, const void *userdata);
 int m_mod_deregister(OUT m_mod_t **mod);
 
-/* Retrieve module context */
-m_ctx_t *m_mod_ctx(const m_mod_t *mod);
-
 /* Retrieve module name */
 const char *m_mod_name(const m_mod_t *mod);
 

--- a/Lib/core/public/module/mod.h
+++ b/Lib/core/public/module/mod.h
@@ -201,7 +201,7 @@ typedef struct {
 /* Module interface functions */
 
 /* Module registration */
-int m_mod_register(const char *name, m_ctx_t *c, OUT m_mod_t **mod_ref, const m_mod_hook_t *hook,
+int m_mod_register(const char *name, OUT m_mod_t **mod_ref, const m_mod_hook_t *hook,
                    m_mod_flags flags, const void *userdata);
 int m_mod_deregister(OUT m_mod_t **mod);
 

--- a/Lib/core/public/module/mod.h
+++ b/Lib/core/public/module/mod.h
@@ -230,7 +230,7 @@ int m_mod_stats(const m_mod_t *mod, OUT m_mod_stats_t *stats);
 
 const void *m_mod_userdata(const m_mod_t *mod);
 
-m_mod_t *m_mod_ref(const m_mod_t *mod, const char *name);
+m_mod_t *m_mod_lookup(const m_mod_t *mod, const char *name);
 
 int m_mod_become(m_mod_t *mod, m_evt_cb new_on_evt);
 int m_mod_unbecome(m_mod_t *mod);

--- a/Lib/core/public/module/mod_easy.h
+++ b/Lib/core/public/module/mod_easy.h
@@ -10,13 +10,9 @@
  * ctors order:
  * 0) each m_mod_on_boot() (only mod_easy API)
  * 1) each m_mod_ctor() (only mod_easy API)
- *
- * dtors order:
- * 0) each m_mod_dtor() (only mod_easy API)
  */
 #define _m_ctor0_         __attribute__((constructor (111)))
 #define _m_ctor1_         __attribute__((constructor (112)))
-#define _m_dtor0_         __attribute__((destructor (111)))
 
 /* Simple macro to automatically manage module lifecycle and callbacks */
 #define M_MOD(name) \
@@ -32,8 +28,5 @@
         } \
         m_mod_hook_t hook = { m_mod_on_start, m_mod_on_eval, m_mod_on_evt, m_mod_on_stop }; \
         m_mod_register(name, _m_ctx, NULL , &hook, M_MOD_PERSIST, NULL); \
-    } \
-    static void _m_dtor0_ m_mod_dtor(void) { \
-        m_mem_unrefp((void **)&_m_ctx); \
     } \
     static void _m_ctor0_ m_mod_on_boot(void)

--- a/Lib/core/public/module/mod_easy.h
+++ b/Lib/core/public/module/mod_easy.h
@@ -6,6 +6,20 @@
 
 #define M_CTX_DEFAULT           "libmodule"
 
+/*
+ * ctors order:
+ * 0) global m_on_boot(), useful to set your own memhook if desired
+ * 1) each m_mod_on_boot() (only mod_easy API)
+ * 2) each m_mod_ctor() (only mod_easy API)
+ *
+ * dtors order:
+ * 0) each m_mod_dtor() (only mod_easy API)
+ */
+#define _m_ctor0_         __attribute__((constructor (110)))
+#define _m_ctor1_         __attribute__((constructor (113)))
+#define _m_ctor2_         __attribute__((constructor (114)))
+#define _m_dtor0_         __attribute__((destructor (111)))
+
 /* Simple macro to automatically manage module lifecycle and callbacks */
 #define M_MOD(name) \
     static bool m_mod_on_start(m_mod_t *mod); \
@@ -13,7 +27,7 @@
     static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts); \
     static void m_mod_on_stop(m_mod_t *mod); \
     static m_ctx_t *_m_ctx; \
-    static void _m_ctor3_ m_m_ctor(void) { \
+    static void _m_ctor2_ m_m_ctor(void) { \
         _m_ctx = m_ctx(); \
         if (!_m_ctx) { \
             m_ctx_register(M_CTX_DEFAULT, &_m_ctx, 0, NULL); \
@@ -21,7 +35,7 @@
         m_mod_hook_t hook = { m_mod_on_start, m_mod_on_eval, m_mod_on_evt, m_mod_on_stop }; \
         m_mod_register(name, _m_ctx, NULL , &hook, M_MOD_PERSIST, NULL); \
     } \
-    static void _m_dtor1_ m_mod_dtor(void) { \
+    static void _m_dtor0_ m_mod_dtor(void) { \
         m_mem_unrefp((void **)&_m_ctx); \
     } \
-    static void _m_ctor2_ m_mod_on_boot(void)
+    static void _m_ctor1_ m_mod_on_boot(void)

--- a/Lib/core/public/module/mod_easy.h
+++ b/Lib/core/public/module/mod_easy.h
@@ -8,16 +8,14 @@
 
 /*
  * ctors order:
- * 0) global m_on_boot(), useful to set your own memhook if desired
- * 1) each m_mod_on_boot() (only mod_easy API)
- * 2) each m_mod_ctor() (only mod_easy API)
+ * 0) each m_mod_on_boot() (only mod_easy API)
+ * 1) each m_mod_ctor() (only mod_easy API)
  *
  * dtors order:
  * 0) each m_mod_dtor() (only mod_easy API)
  */
-#define _m_ctor0_         __attribute__((constructor (110)))
-#define _m_ctor1_         __attribute__((constructor (113)))
-#define _m_ctor2_         __attribute__((constructor (114)))
+#define _m_ctor0_         __attribute__((constructor (113)))
+#define _m_ctor1_         __attribute__((constructor (114)))
 #define _m_dtor0_         __attribute__((destructor (111)))
 
 /* Simple macro to automatically manage module lifecycle and callbacks */
@@ -27,7 +25,7 @@
     static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts); \
     static void m_mod_on_stop(m_mod_t *mod); \
     static m_ctx_t *_m_ctx; \
-    static void _m_ctor2_ m_m_ctor(void) { \
+    static void _m_ctor1_ m_m_ctor(void) { \
         _m_ctx = m_ctx(); \
         if (!_m_ctx) { \
             m_ctx_register(M_CTX_DEFAULT, &_m_ctx, 0, NULL); \
@@ -38,4 +36,4 @@
     static void _m_dtor0_ m_mod_dtor(void) { \
         m_mem_unrefp((void **)&_m_ctx); \
     } \
-    static void _m_ctor1_ m_mod_on_boot(void)
+    static void _m_ctor0_ m_mod_on_boot(void)

--- a/Lib/core/public/module/mod_easy.h
+++ b/Lib/core/public/module/mod_easy.h
@@ -14,7 +14,7 @@
     static void m_mod_on_stop(m_mod_t *mod); \
     static m_ctx_t *_m_ctx; \
     static void _m_ctor3_ m_m_ctor(void) { \
-        _m_ctx = m_ctx_ref(M_CTX_DEFAULT); \
+        _m_ctx = m_ctx_ref(); \
         if (!_m_ctx) { \
             m_ctx_register(M_CTX_DEFAULT, &_m_ctx, 0, NULL); \
         } \

--- a/Lib/core/public/module/mod_easy.h
+++ b/Lib/core/public/module/mod_easy.h
@@ -14,8 +14,8 @@
  * dtors order:
  * 0) each m_mod_dtor() (only mod_easy API)
  */
-#define _m_ctor0_         __attribute__((constructor (113)))
-#define _m_ctor1_         __attribute__((constructor (114)))
+#define _m_ctor0_         __attribute__((constructor (111)))
+#define _m_ctor1_         __attribute__((constructor (112)))
 #define _m_dtor0_         __attribute__((destructor (111)))
 
 /* Simple macro to automatically manage module lifecycle and callbacks */

--- a/Lib/core/public/module/mod_easy.h
+++ b/Lib/core/public/module/mod_easy.h
@@ -20,13 +20,9 @@
     static bool m_mod_on_eval(m_mod_t *mod); \
     static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts); \
     static void m_mod_on_stop(m_mod_t *mod); \
-    static m_ctx_t *_m_ctx; \
     static void _m_ctor1_ m_m_ctor(void) { \
-        _m_ctx = m_ctx(); \
-        if (!_m_ctx) { \
-            m_ctx_register(M_CTX_DEFAULT, &_m_ctx, 0, NULL); \
-        } \
+        m_ctx_register(M_CTX_DEFAULT, 0, NULL); \
         m_mod_hook_t hook = { m_mod_on_start, m_mod_on_eval, m_mod_on_evt, m_mod_on_stop }; \
-        m_mod_register(name, _m_ctx, NULL , &hook, M_MOD_PERSIST, NULL); \
+        m_mod_register(name, NULL , &hook, M_MOD_PERSIST, NULL); \
     } \
     static void _m_ctor0_ m_mod_on_boot(void)

--- a/Lib/core/public/module/mod_easy.h
+++ b/Lib/core/public/module/mod_easy.h
@@ -14,7 +14,7 @@
     static void m_mod_on_stop(m_mod_t *mod); \
     static m_ctx_t *_m_ctx; \
     static void _m_ctor3_ m_m_ctor(void) { \
-        _m_ctx = m_ctx_ref(); \
+        _m_ctx = m_ctx(); \
         if (!_m_ctx) { \
             m_ctx_register(M_CTX_DEFAULT, &_m_ctx, 0, NULL); \
         } \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
         case M_SRC_TYPE_PS:
             if (strcmp((char *)msg->ps_evt->data, "ByeBye") == 0) {
                 m_mod_log("Bye\n"):
-                m_ctx_quit(m_mod_ctx(mod), 0);
+                m_ctx_quit(0);
             }
             break;
         }

--- a/Samples/Easy/doggo.c
+++ b/Samples/Easy/doggo.c
@@ -64,7 +64,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
                      * Test runtime module loading; loaded module won't have direct access to CTX.
                      * We own a ref on it! 
                      */
-                    m_mod_register("./libtestmod.so", m_mod_ctx(mod), &plugin, NULL, M_MOD_DENY_CTX, NULL);
+                    m_mod_register("./libtestmod.so", m_ctx(), &plugin, NULL, M_MOD_DENY_CTX, NULL);
                 } else if (!strcmp((char *)msg->ps_evt->data, "ByeBye")) {
                     m_mod_log(mod, "Sob...\n");
                 } else if (!strcmp((char *)msg->ps_evt->data, "WakeUp")) {
@@ -87,7 +87,7 @@ static void m_mod_on_evt_sleeping(m_mod_t *mod, const m_queue_t *const evts) {
                 if (!strcmp((char *)msg->ps_evt->data, "WakeUp")) {
                     m_mod_unbecome(mod);
                     m_mod_log(mod, "Yawn...\n");
-                    m_ctx_dump(m_mod_ctx(mod));
+                    m_ctx_dump(m_ctx());
                     m_mod_deregister(&plugin);
                     m_mod_src_deregister(mod, M_PS_MOD_STARTED);
                 } else {

--- a/Samples/Easy/doggo.c
+++ b/Samples/Easy/doggo.c
@@ -13,8 +13,8 @@ static void m_mod_on_boot(void) {
 }
 
 #ifdef M_CTX_HAS_FS
-void m_ctx_pre_loop(m_ctx_t *c, int argc, char *argv[]) {
-    m_ctx_fs_set_root(c, "./EasyCtx");
+void m_ctx_pre_loop(int argc, char *argv[]) {
+    m_ctx_fs_set_root("./EasyCtx");
 }
 #endif
 
@@ -64,7 +64,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
                      * Test runtime module loading; loaded module won't have direct access to CTX.
                      * We own a ref on it! 
                      */
-                    m_mod_register("./libtestmod.so", m_ctx(), &plugin, NULL, M_MOD_DENY_CTX, NULL);
+                    m_mod_register("./libtestmod.so", &plugin, NULL, M_MOD_DENY_CTX, NULL);
                 } else if (!strcmp((char *)msg->ps_evt->data, "ByeBye")) {
                     m_mod_log(mod, "Sob...\n");
                 } else if (!strcmp((char *)msg->ps_evt->data, "WakeUp")) {
@@ -87,7 +87,7 @@ static void m_mod_on_evt_sleeping(m_mod_t *mod, const m_queue_t *const evts) {
                 if (!strcmp((char *)msg->ps_evt->data, "WakeUp")) {
                     m_mod_unbecome(mod);
                     m_mod_log(mod, "Yawn...\n");
-                    m_ctx_dump(m_ctx());
+                    m_ctx_dump();
                     m_mod_deregister(&plugin);
                     m_mod_src_deregister(mod, M_PS_MOD_STARTED);
                 } else {

--- a/Samples/Easy/pippo.c
+++ b/Samples/Easy/pippo.c
@@ -42,7 +42,7 @@ static bool m_mod_on_start(m_mod_t *mod) {
     doggo = m_mod_lookup(mod, "Doggo");
     
     // let context tick every 5s and subscribe to it
-    m_ctx_set_tick(m_mod_ctx(mod), (uint64_t)5 * 1000 * 1000 * 1000);
+    m_ctx_set_tick(m_ctx(), (uint64_t)5 * 1000 * 1000 * 1000);
     m_mod_src_register(mod, M_PS_CTX_TICK, 0, NULL);
     return true;
 }
@@ -86,7 +86,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'q':
                     m_mod_log(mod, "I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", "ByeBye", 0);
-                    m_ctx_quit(m_mod_ctx(mod), 0);
+                    m_ctx_quit(m_ctx(), 0);
                     break;
                 default:
                     /* Avoid newline */
@@ -96,7 +96,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
                     break;
             }
         } else if (strcmp((char *)msg->ps_evt->data, "BauBau") == 0) {
-            m_ctx_dump(m_mod_ctx(mod));
+            m_ctx_dump(m_ctx());
             m_mod_become(mod, m_mod_on_evt_ready);
             m_mod_log(mod, "Press 'p' to play with Doggo! Or 'f' to feed your Doggo. 's' to have a nap. 'w' to wake him up. 'q' to leave him for now.\n");
         }
@@ -146,7 +146,7 @@ static void m_mod_on_evt_ready(m_mod_t *mod, const m_queue_t *const evts) {
                     m_mod_dump(mod);
                     m_mod_log(mod, "I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", "ByeBye", 0);
-                    m_ctx_quit(m_mod_ctx(mod), 0);
+                    m_ctx_quit(m_ctx(), 0);
                     break;
                 default:
                     /* Avoid newline */
@@ -159,7 +159,7 @@ static void m_mod_on_evt_ready(m_mod_t *mod, const m_queue_t *const evts) {
             m_mod_log(mod, "Received ctx tick.\n");
             if (++tick_ctr == 5) {
                 m_mod_log(mod, "Stop playing and get back to do stuff!\n");
-                m_ctx_quit(m_mod_ctx(mod), -EPIPE);
+                m_ctx_quit(m_ctx(), -EPIPE);
             }
         }
     });

--- a/Samples/Easy/pippo.c
+++ b/Samples/Easy/pippo.c
@@ -42,7 +42,7 @@ static bool m_mod_on_start(m_mod_t *mod) {
     doggo = m_mod_lookup(mod, "Doggo");
     
     // let context tick every 5s and subscribe to it
-    m_ctx_set_tick(m_ctx(), (uint64_t)5 * 1000 * 1000 * 1000);
+    m_ctx_set_tick((uint64_t)5 * 1000 * 1000 * 1000);
     m_mod_src_register(mod, M_PS_CTX_TICK, 0, NULL);
     return true;
 }
@@ -86,7 +86,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'q':
                     m_mod_log(mod, "I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", "ByeBye", 0);
-                    m_ctx_quit(m_ctx(), 0);
+                    m_ctx_quit(0);
                     break;
                 default:
                     /* Avoid newline */
@@ -96,7 +96,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
                     break;
             }
         } else if (strcmp((char *)msg->ps_evt->data, "BauBau") == 0) {
-            m_ctx_dump(m_ctx());
+            m_ctx_dump();
             m_mod_become(mod, m_mod_on_evt_ready);
             m_mod_log(mod, "Press 'p' to play with Doggo! Or 'f' to feed your Doggo. 's' to have a nap. 'w' to wake him up. 'q' to leave him for now.\n");
         }
@@ -146,7 +146,7 @@ static void m_mod_on_evt_ready(m_mod_t *mod, const m_queue_t *const evts) {
                     m_mod_dump(mod);
                     m_mod_log(mod, "I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", "ByeBye", 0);
-                    m_ctx_quit(m_ctx(), 0);
+                    m_ctx_quit(0);
                     break;
                 default:
                     /* Avoid newline */
@@ -159,7 +159,7 @@ static void m_mod_on_evt_ready(m_mod_t *mod, const m_queue_t *const evts) {
             m_mod_log(mod, "Received ctx tick.\n");
             if (++tick_ctr == 5) {
                 m_mod_log(mod, "Stop playing and get back to do stuff!\n");
-                m_ctx_quit(m_ctx(), -EPIPE);
+                m_ctx_quit(-EPIPE);
             }
         }
     });

--- a/Samples/Easy/pippo.c
+++ b/Samples/Easy/pippo.c
@@ -39,7 +39,7 @@ static bool m_mod_on_start(m_mod_t *mod) {
 #endif
     
     /* Get Doggo module reference */
-    doggo = m_mod_ref(mod, "Doggo");
+    doggo = m_mod_lookup(mod, "Doggo");
     
     // let context tick every 5s and subscribe to it
     m_ctx_set_tick(m_mod_ctx(mod), (uint64_t)5 * 1000 * 1000 * 1000);
@@ -52,7 +52,7 @@ static bool m_mod_on_eval(m_mod_t *mod) {
 }
 
 static void m_mod_on_stop(m_mod_t *mod) {
-    m_mem_unrefp((void **)&doggo);
+
 }
 
 static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {

--- a/Samples/Poll/main.c
+++ b/Samples/Poll/main.c
@@ -16,7 +16,7 @@ void m_on_boot(void) {
 int main(int argc, char *argv[]) {
     int ret = 0;
     
-    m_ctx_t *c = m_ctx_ref(M_CTX_DEFAULT);
+    m_ctx_t *c = m_ctx_ref();
     if (!c) {
         fprintf(stderr, "No ctx found.\n");
         return -1;

--- a/Samples/Poll/main.c
+++ b/Samples/Poll/main.c
@@ -16,19 +16,13 @@ void m_on_boot(void) {
 int main(int argc, char *argv[]) {
     int ret = 0;
     
-    m_ctx_t *c = m_ctx();
-    if (!c) {
-        fprintf(stderr, "No ctx found.\n");
-        return -1;
-    }
-    
     /* Initial dispatch */
-    if (m_ctx_dispatch(c) != 0) {
+    if (m_ctx_dispatch() != 0) {
         return 1;
     }
 
     /* Get context fd */
-    int fd = m_ctx_fd(c);
+    int fd = m_ctx_fd();
     if (fd < 0) {
         return 1;
     }
@@ -41,7 +35,7 @@ int main(int argc, char *argv[]) {
         ret = poll(&fds, 1, -1);
         if (ret > 0) {
             if (fds.revents & POLLIN) {
-                ret = m_ctx_dispatch(c);
+                ret = m_ctx_dispatch();
                 if (ret < 0) {
                     printf("Loop: error happened.\n");
                 } else if (ret > 0) {
@@ -54,7 +48,6 @@ int main(int argc, char *argv[]) {
         }
     }
     close(fd);
-    m_ctx_deregister(&c);
-    m_mem_unrefp((void **)&c);
+    m_ctx_deregister();
     return 0;
 }

--- a/Samples/Poll/main.c
+++ b/Samples/Poll/main.c
@@ -16,7 +16,7 @@ void m_on_boot(void) {
 int main(int argc, char *argv[]) {
     int ret = 0;
     
-    m_ctx_t *c = m_ctx_ref();
+    m_ctx_t *c = m_ctx();
     if (!c) {
         fprintf(stderr, "No ctx found.\n");
         return -1;

--- a/Samples/Poll/pippo.c
+++ b/Samples/Poll/pippo.c
@@ -59,7 +59,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'q':
                     m_mod_log(mod,"I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", "ByeBye", 0);
-                    m_ctx_quit(m_ctx(), 0);
+                    m_ctx_quit(0);
                     break;
                 default:
                     /* Avoid newline */
@@ -99,7 +99,7 @@ static void m_mod_on_evt_ready(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'p':
                     m_mod_log(mod,"Doggo, let's play a bit!\n");
                     m_mod_ps_tell(mod, doggo, "LetsPlay", 0);
-                    m_ctx_dump(m_ctx());
+                    m_ctx_dump();
                     break;
                 case 's':
                     m_mod_log(mod,"Doggo, you should sleep a bit!\n");
@@ -116,7 +116,7 @@ static void m_mod_on_evt_ready(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'q':
                     m_mod_log(mod, "I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", "ByeBye", 0);
-                    m_ctx_quit(m_ctx(), 0);
+                    m_ctx_quit(0);
                     break;
                 default:
                     /* Avoid newline */

--- a/Samples/Poll/pippo.c
+++ b/Samples/Poll/pippo.c
@@ -59,7 +59,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'q':
                     m_mod_log(mod,"I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", "ByeBye", 0);
-                    m_ctx_quit(m_mod_ctx(mod), 0);
+                    m_ctx_quit(m_ctx(), 0);
                     break;
                 default:
                     /* Avoid newline */
@@ -99,7 +99,7 @@ static void m_mod_on_evt_ready(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'p':
                     m_mod_log(mod,"Doggo, let's play a bit!\n");
                     m_mod_ps_tell(mod, doggo, "LetsPlay", 0);
-                    m_ctx_dump(m_mod_ctx(mod));
+                    m_ctx_dump(m_ctx());
                     break;
                 case 's':
                     m_mod_log(mod,"Doggo, you should sleep a bit!\n");
@@ -116,7 +116,7 @@ static void m_mod_on_evt_ready(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'q':
                     m_mod_log(mod, "I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", "ByeBye", 0);
-                    m_ctx_quit(m_mod_ctx(mod), 0);
+                    m_ctx_quit(m_ctx(), 0);
                     break;
                 default:
                     /* Avoid newline */

--- a/Samples/Poll/pippo.c
+++ b/Samples/Poll/pippo.c
@@ -22,7 +22,7 @@ static bool m_mod_on_start(m_mod_t *mod) {
     m_mod_src_register(mod, STDIN_FILENO, 0, NULL);
     
     /* Get Doggo reference */
-    doggo = m_mod_ref(mod, "Doggo");
+    doggo = m_mod_lookup(mod, "Doggo");
     return true;
 }
 
@@ -31,7 +31,7 @@ static bool m_mod_on_eval(m_mod_t *mod) {
 }
 
 static void m_mod_on_stop(m_mod_t *mod) {
-    m_mem_unrefp((void **)&doggo);
+
 }
 
 static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {

--- a/Samples/SharedSrc/main.c
+++ b/Samples/SharedSrc/main.c
@@ -1,7 +1,7 @@
 #include <module/ctx.h>
 #include <module/mod.h>
 
-extern void create_modules(m_ctx_t *c);
+extern void create_modules(void);
 
 /*
  * This function is automatically called before initing any module.
@@ -17,22 +17,21 @@ int main(int argc, char *argv[]) {
     /*
      * Register the context
      */
-    m_ctx_t *c = NULL;
-    m_ctx_register("SharedSrc", &c, 0, NULL);
+    m_ctx_register("SharedSrc", 0, NULL);
 
     /*
      * Create the modules in the context
      */
-    create_modules(c);
+    create_modules();
 
     /*
      * Loop on context to fetch modules' events
      */
-    m_ctx_loop(c);
+    m_ctx_loop();
     
     /*
      * Finally, destroy the context, thus destroying its modules too.
      */
-    m_ctx_deregister(&c);
+    m_ctx_deregister();
     return 0;
 }

--- a/Samples/SharedSrc/mod.c
+++ b/Samples/SharedSrc/mod.c
@@ -28,7 +28,7 @@ void create_modules(m_ctx_t *c) {
 }
 
 static bool A_init(m_mod_t *mod) {
-    refB = m_mod_ref(mod, "Doggo");
+    refB = m_mod_lookup(mod, "Doggo");
     m_mod_src_register(mod, STDIN_FILENO, 0, NULL);
     return true;
 }
@@ -40,7 +40,7 @@ static bool B_init(m_mod_t *mod) {
 }
 
 static void A_dtor(m_mod_t *mod) {
-    m_mem_unref(refB);
+
 }
 
 /*

--- a/Samples/SharedSrc/mod.c
+++ b/Samples/SharedSrc/mod.c
@@ -19,12 +19,12 @@ static m_mod_t *refB;
  * Create "A" and "B" modules in ctx_name context.
  * These modules can share some callbacks.
  */
-void create_modules(m_ctx_t *c) {
+void create_modules(void) {
     m_mod_hook_t hookA = (m_mod_hook_t) {A_init, NULL, A_recv, A_dtor };
     m_mod_hook_t hookB = (m_mod_hook_t) {B_init, NULL, B_recv, NULL };
     
-    m_mod_register("Pippo", c, NULL, &hookA, 0, NULL);
-    m_mod_register("Doggo", c, NULL, &hookB, 0, NULL);
+    m_mod_register("Pippo", NULL, &hookA, 0, NULL);
+    m_mod_register("Doggo", NULL, &hookB, 0, NULL);
 }
 
 static bool A_init(m_mod_t *mod) {
@@ -61,7 +61,7 @@ static void A_recv(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'q':
                     m_mod_log(mod, "I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", (unsigned char *)"ByeBye", 0);
-                    m_ctx_quit(m_ctx(), 0);
+                    m_ctx_quit(0);
                     break;
                 default:
                     /* Avoid newline */
@@ -106,7 +106,7 @@ static void A_recv_ready(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'q':
                     m_mod_log(mod, "I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", (unsigned char *)"ByeBye", 0);
-                    m_ctx_quit(m_ctx(), 0);
+                    m_ctx_quit(0);
                     break;
                 default:
                     /* Avoid newline */

--- a/Samples/SharedSrc/mod.c
+++ b/Samples/SharedSrc/mod.c
@@ -61,7 +61,7 @@ static void A_recv(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'q':
                     m_mod_log(mod, "I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", (unsigned char *)"ByeBye", 0);
-                    m_ctx_quit(m_mod_ctx(mod), 0);
+                    m_ctx_quit(m_ctx(), 0);
                     break;
                 default:
                     /* Avoid newline */
@@ -106,7 +106,7 @@ static void A_recv_ready(m_mod_t *mod, const m_queue_t *const evts) {
                 case 'q':
                     m_mod_log(mod, "I have to go now!\n");
                     m_mod_ps_publish(mod, "leaving", (unsigned char *)"ByeBye", 0);
-                    m_ctx_quit(m_mod_ctx(mod), 0);
+                    m_ctx_quit(m_ctx(), 0);
                     break;
                 default:
                     /* Avoid newline */

--- a/Samples/Task/pippo.c
+++ b/Samples/Task/pippo.c
@@ -50,7 +50,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
             int *data = (int *)msg->userdata;
             if (*data == 5) {
                 m_mod_log(mod, "Timed out.\n");
-                m_ctx_quit(m_mod_ctx(mod), 0);
+                m_ctx_quit(m_ctx(), 0);
                 m_mod_log(mod,"Final data val: %d\n", thData);
             } else {
                 (*data)++;

--- a/Samples/Task/pippo.c
+++ b/Samples/Task/pippo.c
@@ -12,12 +12,12 @@ static int tmrData;
 static int inc(void *udata);
 
 /* Hook on m_ctx_pre_loop() weak symbol */
-void m_ctx_pre_loop(m_ctx_t *c, int argc, char *argv[]) {
+void m_ctx_pre_loop(int argc, char *argv[]) {
     printf("Task example starting.\n");
 }
 
 /* Hook on m_ctx_post_loop() weak symbol */
-void m_ctx_post_loop(m_ctx_t *c, int argc, char *argv[]) {
+void m_ctx_post_loop(int argc, char *argv[]) {
     printf("Task example ended.\n");
 }
 
@@ -50,7 +50,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
             int *data = (int *)msg->userdata;
             if (*data == 5) {
                 m_mod_log(mod, "Timed out.\n");
-                m_ctx_quit(m_ctx(), 0);
+                m_ctx_quit(0);
                 m_mod_log(mod,"Final data val: %d\n", thData);
             } else {
                 (*data)++;

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@
 - - [x] drop m_ctx_t param from ctx.h API
 - - [x] drop m_ctx_t forward declaration as it is now invisible to user
 - - [x] drop M_CTX_ZOMBIE
-- - [ ] properly enforce that a module API cannot be called when m_ctx() != mod->ctx (ie: if you pass a module around between threads/contexts)
+- - [x] properly enforce that a module API cannot be called when m_ctx() != mod->ctx (ie: if you pass a module around between threads/contexts)
 - - [x] drop libmodule_init() and deinit() constructors
 - - [x] move ctor defines into mod_easy.h
 - - [x] drop m_on_boot(); specify that mod_easy API force-uses malloc,calloc and free by default.

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@
 - - [x] global ctx map and mutex
 - - [ ] m_mod_ctx() api
 - - [x] m_ctx_ref() api
-- - [ ] m_mod_ref() api should become m_mod_lookup() and let users manage its lifecyle (ie: m_mem_ref it if needed)
+- - [x] m_mod_ref() api should become m_mod_lookup() and let users manage its lifecyle (ie: m_mem_ref it if needed)
 - - [ ] m_mod_t->ctx field -> this would help us enforce that module API is called by same thread that registered a context
 - - [ ] drop m_ctx_t param from funtion calls
 - - [x] drop libmodule_init() and deinit() constructors

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 - [x] store ctxs in thread local storage (pthread_setspecific API)? https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_key_create.html `__find_thread_by_id` and loop over /proc/self/task? -> https://stackoverflow.com/questions/3707358/get-all-the-thread-id-created-with-pthread-created-within-an-process
 - [ ] we could then drop: (since every context is thread specific data)
 - - [x] global ctx map and mutex
-- - [ ] m_mod_ctx() api
+- - [x] m_mod_ctx() api
 - - [x] m_ctx_ref() api
 - - [x] m_mod_ref() api should become m_mod_lookup() and let users manage its lifecyle (ie: m_mem_ref it if needed)
 - - [ ] m_mod_t->ctx field -> this would help us enforce that module API is called by same thread that registered a context

--- a/TODO.md
+++ b/TODO.md
@@ -4,22 +4,22 @@
 
 #### Ctx
 
-- [x] Only attach ctx internal srcs when ctx starts looping, and detach them when ctx stops looping, just like we do for modules
-- [ ] add back multictx mod easy support (M_MOD_CTX macro + main that loops on any registered ctx)?
-
-- [ ] store ctxs in thread local storage (pthread_setspecific API)? https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_key_create.html `__find_thread_by_id` and loop over /proc/self/task? -> https://stackoverflow.com/questions/3707358/get-all-the-thread-id-created-with-pthread-created-within-an-process
+- [x] store ctxs in thread local storage (pthread_setspecific API)? https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_key_create.html `__find_thread_by_id` and loop over /proc/self/task? -> https://stackoverflow.com/questions/3707358/get-all-the-thread-id-created-with-pthread-created-within-an-process
 - [ ] we could then drop: (since every context is thread specific data)
-- - [ ] global ctx map and mutex
-- - [ ] m_mod_ctx() api
-- - [ ] m_ctx_ref() api
-- - [ ] m_mod_t->ctx field
+- - [x] global ctx map and mutex
+- - [ ] m_mod_ctx() api -> NOPE this checks if current mod has perm to get ctx. Drop mod PERM management? (fiven m_ctx_ref API it is a noop btw)
+- - [ ] m_ctx_ref() api -> but if there is this API, is the whole PERM_CTX on mod useful?
+- - [ ] m_mod_t->ctx field -> if we drop PERM management, we can drop this, and this would help us enforce that module API is called by same thread that registered a context
+- - [ ] drop m_ctx_t param from funtion calls
+- - [ ] drop libmodule_init() and deinit() constructors
+- - [ ] Specify that m_set_memhook should be called before allocating any libmodule related resource (ie: m_on_boot() for mod_easy, or before allocating first ctx, when manually)
 - [ ] and just add an m_ctx() API that returns ctx associated with current thread
 - [ ] Downside: how could we guarantee that 2 ctx with same name do not exist? We cannot; is this a limitation, actually?
 
 #### DOC
 
 - [x] Fully rewrite documentation per-namespace
-- [ ] Document that m_{mod,ctx}_deregister() should not be called inside user hook { on_start(), on_stop(), on_eval() } functions; m_mod_deregister() can be used from on_evt() though.  (IS THIS WHOLE SENTENCE TRUE?)
+- [ ] Document that m_{mod,ctx}_deregister() should not be called inside user hook { on_start(), on_stop(), on_eval() } functions; m_mod_deregister() can be used from on_evt() though.  (IS THIS WHOLE SENTENCE TRUE?) (ctx: `M_PARAM_ASSERT(c && *c && (*c)->state == M_CTX_IDLE);`)
 - [ ] document m_evt_t memref'd behaviour!!!
 - [ ] Document stats and thresh activity_freq (num_action_per_ms)
 

--- a/TODO.md
+++ b/TODO.md
@@ -14,9 +14,10 @@
 - - [ ] drop m_ctx_t param from funtion calls
 - - [x] drop libmodule_init() and deinit() constructors
 - - [x] move ctor defines into mod_easy.h
-- - [ ] Specify that m_set_memhook should be called before allocating any libmodule related resource (ie: m_on_boot() for mod_easy, or before allocating first ctx, when manually)
+- - [x] drop m_on_boot(); specify that mod_easy API force-uses malloc,calloc and free by default.
+- - [x] Specify that m_set_memhook should be called before allocating any libmodule related resource
 - [x] and just add an m_ctx() API that returns ctx associated with current thread
-- [x] store in ctx a `void **curr_mod` that points to the module whose callback is currently being processed, if any, or NULL; when NULL; we are outside a module callback, therefore we can return it; else, we must guarantee that module has permissions to access its ctx
+- [x] store in ctx a `curr_mod` that points to the module whose callback is currently being processed, if any, or NULL; when NULL; we are outside a module callback, therefore we can return it; else, we must guarantee that module has permissions to access its ctx
 - [ ] Downside: how could we guarantee that 2 ctx with same name do not exist? We cannot; is this a limitation, actually?
 
 #### DOC

--- a/TODO.md
+++ b/TODO.md
@@ -7,19 +7,21 @@
 - [x] store ctxs in thread local storage (pthread_setspecific API)? https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_key_create.html `__find_thread_by_id` and loop over /proc/self/task? -> https://stackoverflow.com/questions/3707358/get-all-the-thread-id-created-with-pthread-created-within-an-process
 - [ ] we could then drop: (since every context is thread specific data)
 - - [x] global ctx map and mutex
-- - [ ] m_mod_ctx() api -> NOPE this checks if current mod has perm to get ctx. Drop mod PERM management? (fiven m_ctx_ref API it is a noop btw)
-- - [ ] m_ctx_ref() api -> but if there is this API, is the whole PERM_CTX on mod useful?
-- - [ ] m_mod_t->ctx field -> if we drop PERM management, we can drop this, and this would help us enforce that module API is called by same thread that registered a context
+- - [ ] m_mod_ctx() api
+- - [x] m_ctx_ref() api
+- - [ ] m_mod_ref() api should become m_mod_lookup() and let users manage its lifecyle (ie: m_mem_ref it if needed)
+- - [ ] m_mod_t->ctx field -> this would help us enforce that module API is called by same thread that registered a context
 - - [ ] drop m_ctx_t param from funtion calls
 - - [ ] drop libmodule_init() and deinit() constructors
 - - [ ] Specify that m_set_memhook should be called before allocating any libmodule related resource (ie: m_on_boot() for mod_easy, or before allocating first ctx, when manually)
-- [ ] and just add an m_ctx() API that returns ctx associated with current thread
+- [x] and just add an m_ctx() API that returns ctx associated with current thread
+- [x] store in ctx a `void **curr_mod` that points to the module whose callback is currently being processed, if any, or NULL; when NULL; we are outside a module callback, therefore we can return it; else, we must guarantee that module has permissions to access its ctx
 - [ ] Downside: how could we guarantee that 2 ctx with same name do not exist? We cannot; is this a limitation, actually?
 
 #### DOC
 
 - [x] Fully rewrite documentation per-namespace
-- [ ] Document that m_{mod,ctx}_deregister() should not be called inside user hook { on_start(), on_stop(), on_eval() } functions; m_mod_deregister() can be used from on_evt() though.  (IS THIS WHOLE SENTENCE TRUE?) (ctx: `M_PARAM_ASSERT(c && *c && (*c)->state == M_CTX_IDLE);`)
+- [ ] Document that m_ctx_deregister() cannot be called on a looping context (`M_PARAM_ASSERT(c && *c && (*c)->state == M_CTX_IDLE);`)
 - [ ] document m_evt_t memref'd behaviour!!!
 - [ ] Document stats and thresh activity_freq (num_action_per_ms)
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,8 @@
 - - [ ] m_mod_ref() api should become m_mod_lookup() and let users manage its lifecyle (ie: m_mem_ref it if needed)
 - - [ ] m_mod_t->ctx field -> this would help us enforce that module API is called by same thread that registered a context
 - - [ ] drop m_ctx_t param from funtion calls
-- - [ ] drop libmodule_init() and deinit() constructors
+- - [x] drop libmodule_init() and deinit() constructors
+- - [x] move ctor defines into mod_easy.h
 - - [ ] Specify that m_set_memhook should be called before allocating any libmodule related resource (ie: m_on_boot() for mod_easy, or before allocating first ctx, when manually)
 - [x] and just add an m_ctx() API that returns ctx associated with current thread
 - [x] store in ctx a `void **curr_mod` that points to the module whose callback is currently being processed, if any, or NULL; when NULL; we are outside a module callback, therefore we can return it; else, we must guarantee that module has permissions to access its ctx

--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,7 @@
 #### DOC
 
 - [x] Fully rewrite documentation per-namespace
-- [ ] Document that m_ctx_deregister() cannot be called on a looping context (`M_PARAM_ASSERT(c && *c && (*c)->state == M_CTX_IDLE);`)
+- [x] Document that m_ctx_deregister() cannot be called on a looping context (`M_PARAM_ASSERT(c && *c && (*c)->state == M_CTX_IDLE);`)
 - [ ] document m_evt_t memref'd behaviour!!!
 - [ ] Document stats and thresh activity_freq (num_action_per_ms)
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,8 +10,10 @@
 - - [x] m_mod_ctx() api
 - - [x] m_ctx_ref() api
 - - [x] m_mod_ref() api should become m_mod_lookup() and let users manage its lifecyle (ie: m_mem_ref it if needed)
-- - [ ] m_mod_t->ctx field -> this would help us enforce that module API is called by same thread that registered a context
-- - [ ] drop m_ctx_t param from funtion calls
+- - [x] drop m_ctx_t param from ctx.h API
+- - [x] drop m_ctx_t forward declaration as it is now invisible to user
+- - [x] drop M_CTX_ZOMBIE
+- - [ ] properly enforce that a module API cannot be called when m_ctx() != mod->ctx (ie: if you pass a module around between threads/contexts)
 - - [x] drop libmodule_init() and deinit() constructors
 - - [x] move ctor defines into mod_easy.h
 - - [x] drop m_on_boot(); specify that mod_easy API force-uses malloc,calloc and free by default.

--- a/TODO.md
+++ b/TODO.md
@@ -2,26 +2,6 @@
 
 ### TODO
 
-#### Ctx
-
-- [x] store ctxs in thread local storage (pthread_setspecific API)? https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_key_create.html `__find_thread_by_id` and loop over /proc/self/task? -> https://stackoverflow.com/questions/3707358/get-all-the-thread-id-created-with-pthread-created-within-an-process
-- [ ] we could then drop: (since every context is thread specific data)
-- - [x] global ctx map and mutex
-- - [x] m_mod_ctx() api
-- - [x] m_ctx_ref() api
-- - [x] m_mod_ref() api should become m_mod_lookup() and let users manage its lifecyle (ie: m_mem_ref it if needed)
-- - [x] drop m_ctx_t param from ctx.h API
-- - [x] drop m_ctx_t forward declaration as it is now invisible to user
-- - [x] drop M_CTX_ZOMBIE
-- - [x] properly enforce that a module API cannot be called when m_ctx() != mod->ctx (ie: if you pass a module around between threads/contexts)
-- - [x] drop libmodule_init() and deinit() constructors
-- - [x] move ctor defines into mod_easy.h
-- - [x] drop m_on_boot(); specify that mod_easy API force-uses malloc,calloc and free by default.
-- - [x] Specify that m_set_memhook should be called before allocating any libmodule related resource
-- [x] and just add an m_ctx() API that returns ctx associated with current thread
-- [x] store in ctx a `curr_mod` that points to the module whose callback is currently being processed, if any, or NULL; when NULL; we are outside a module callback, therefore we can return it; else, we must guarantee that module has permissions to access its ctx
-- [ ] Downside: how could we guarantee that 2 ctx with same name do not exist? We cannot; is this a limitation, actually?
-
 #### DOC
 
 - [x] Fully rewrite documentation per-namespace

--- a/docs/concepts/concepts.md
+++ b/docs/concepts/concepts.md
@@ -44,10 +44,9 @@ Ctor order is specified in each namespace doc.
 ### Memhook
 
 Moreover, libmodule allows users to override default memhook used, by calling `m_set_memhook()`.  
-This function must be called from `m_on_boot()` function, because it has to be called before any internal ctor is run, ie: before any allocation takes place.  
+This function must be called before any libmodule's allocation takes place, ie: before calling the first `m_ctx_register`.  
 A memhook is just a wrapper around 3 main memory related functions:  
 
 * `malloc`  
 * `calloc`  
 * `free`  
-

--- a/docs/concepts/ctx.md
+++ b/docs/concepts/ctx.md
@@ -4,6 +4,10 @@ A context can be seen as a collector for modules. You can loop on events from ea
 It is stored as a [thread specific object](https://linux.die.net/man/3/pthread_setspecific), created through `m_ctx_register` and deleted through `m_ctx_deregister`.  
 This can be particularly useful when dealing with 2+ threads; each thread has its own module's context and thus its own events to be polled.  
 Modules can only see and reach (through PubSub messaging) other modules from same context.  
+A context is given a name at registration time. This is only useful for logging purposes.  
+
+> NOTE: having multiple contexts with same name is allowed; given that each context is thread-specific, there will be no clash.  
+> Of course, it's better to set different names.  
 
 ## Loop
 

--- a/docs/concepts/ctx.md
+++ b/docs/concepts/ctx.md
@@ -1,7 +1,8 @@
 # Context
 
 A context can be seen as a collector for modules. You can loop on events from each context, and each context behaves independently from others.  
-This can be particularly useful when dealing with 2+ threads; ideally, each thread has its own module's context and thus its own events to be polled.  
+It is stored as a [thread specific object](https://linux.die.net/man/3/pthread_setspecific), created through `m_ctx_register` and deleted through `m_ctx_deregister`.  
+This can be particularly useful when dealing with 2+ threads; each thread has its own module's context and thus its own events to be polled.  
 Modules can only see and reach (through PubSub messaging) other modules from same context.  
 
 ## Loop

--- a/docs/core/core.md
+++ b/docs/core/core.md
@@ -14,23 +14,6 @@ For the sake of readiness, function params where an output value will be stored,
 
 > **All the libmodule core API returns an errno-style negative error code, where left unspecified.**
 
-## Constructors
-
-Libmodule makes heavy usage of gcc `__attribute__((constructor))` (and destructor) to inizialize itself.  
-The order is the following:
-
-**Ctors**  
-
-* `m_on_boot()`
-* internal `libmodule_init()`
-* each `m_mod_on_boot()` (only mod_easy API)
-* each `m_mod_ctor()` (only mod_easy API)
-
-**Dtors**  
-
-* each `m_mod_dtor()` (only mod_easy API)
-* internal `libmodule_deinit()`
-
 ## Memory
 
 ### Ref counted

--- a/docs/core/ctx.md
+++ b/docs/core/ctx.md
@@ -58,7 +58,7 @@ int m_ctx_deregister(m_ctx_t **c);
 * `c`: ctx handler storage, reset to NULL after the call  
 
 ```C
-m_ctx_t *m_ctx(const char *ctx_name);
+m_ctx_t *m_ctx(void);
 ```
 > Retrieves ctx associated with current thread, if existent.  
 > NOTE: this API **does not** increment number of references on ctx object;  

--- a/docs/core/ctx.md
+++ b/docs/core/ctx.md
@@ -58,11 +58,12 @@ int m_ctx_deregister(m_ctx_t **c);
 * `c`: ctx handler storage, reset to NULL after the call  
 
 ```C
-m_ctx_t *m_ctx_ref(const char *ctx_name);
+m_ctx_t *m_ctx(const char *ctx_name);
 ```
-> Get a reference on a ctx, if existent.  
-> NOTE: this API increments number of reference on ctx object;  
-> remember to `m_mem_unref` the reference when you do not need it anymore.  
+> Retrieves ctx associated with current thread, if existent.  
+> NOTE: this API **does not** increment number of references on ctx object;  
+> remember to `m_mem_ref` the returned pointer if you want to store it,  
+> and then `m_mem_unref` it, when you do not need it anymore.  
 
 **Params:**  
 

--- a/docs/core/ctx.md
+++ b/docs/core/ctx.md
@@ -52,6 +52,10 @@ int m_ctx_register(const char *ctx_name, m_ctx_t **c, m_ctx_flags flags, const v
 int m_ctx_deregister(m_ctx_t **c);
 ```
 > Deregister a ctx.  
+> NOTE: this API cannot be called if the ctx is still looping.  
+> Make sure to `m_ctx_quit` the loop before deregistering a context.  
+> NOTE: unless a ctx is registered with `M_CTX_PERSIST` flag, it will get  
+> automatically destroyed when there are no more modules registered in it.  
 
 **Params:**  
 

--- a/docs/core/mod.md
+++ b/docs/core/mod.md
@@ -3,5 +3,5 @@
 Mod API denotes libmodule interface functions to manage modules.  
 It can be found in `<module/mod.h>` header.  
 
-> **All the ctx API expects a non-NULL ctx handler**, except for ... functions.  
+> **All the mod API expects a non-NULL mod handler**, except for ... functions.  
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ static void m_mod_on_evt(m_mod_t *mod, const m_queue_t *const evts) {
         case M_SRC_TYPE_PS:
             if (strcmp((char *)msg->ps_evt->data, "ByeBye") == 0) {
                 m_mod_log("Bye\n"):
-                m_ctx_quit(m_mod_ctx(mod), 0);
+                m_ctx_quit(0);
             }
             break;
         }

--- a/tests/main.c
+++ b/tests/main.c
@@ -14,8 +14,7 @@ int main(void) {
     const struct CMUnitTest tests[] = {
         /* Test module_register failures */
         cmocka_unit_test(test_mod_register_NULL_name),
-        cmocka_unit_test(test_mod_register_NULL_hook),
-
+        
         /* Test ctx register */
         cmocka_unit_test(test_ctx_register_NULL_name),
         cmocka_unit_test(test_ctx_register),

--- a/tests/main.c
+++ b/tests/main.c
@@ -128,7 +128,6 @@ int main(void) {
         cmocka_unit_test(test_mod_false_init),
 
         /* Test ctx deregister */
-        cmocka_unit_test(test_ctx_deregister_NULL_name),
         cmocka_unit_test(test_ctx_deregister),
         
         /* Test modules_ API: it should fail now */

--- a/tests/test_commons.h
+++ b/tests/test_commons.h
@@ -8,4 +8,3 @@
 #include <string.h>
 
 extern m_mod_t *test_mod;
-extern m_ctx_t *test_ctx;

--- a/tests/test_ctx.c
+++ b/tests/test_ctx.c
@@ -13,7 +13,7 @@ static void logger(const m_mod_t *self, const char *fmt, va_list args) {
     const char *context = NULL;
     if (self) {
         name = m_mod_name(self);
-        context = m_ctx_name(m_mod_ctx(self));
+        context = m_ctx_name(m_ctx());
     }
     printf("%s@%s:\t* ", name ? name : "null", context ? context : "null");
     vprintf(fmt, args);

--- a/tests/test_ctx.h
+++ b/tests/test_ctx.h
@@ -2,7 +2,6 @@
 
 void test_ctx_register_NULL_name(void **state);
 void test_ctx_register(void **state);
-void test_ctx_deregister_NULL_name(void **state);
 void test_ctx_deregister(void **state);
 void test_ctx_set_logger_NULL_logger(void **state);
 void test_ctx_set_logger(void **state);

--- a/tests/test_evt_ref.c
+++ b/tests/test_evt_ref.c
@@ -11,13 +11,11 @@ static m_evt_t *ref;
 void test_evt_ref(void **state) {
     (void) state; /* unused */
 
-    test_ctx = NULL;
-    int ret = m_ctx_register("evt_ref", &test_ctx, 0, NULL);
+    int ret = m_ctx_register("evt_ref", 0, NULL);
     assert_true(ret == 0);
-    assert_non_null(test_ctx);
 
     m_mod_hook_t hook = { .on_evt = my_recv };
-    ret = m_mod_register("testName", test_ctx, &mod, &hook, 0, NULL);
+    ret = m_mod_register("testName", &mod, &hook, 0, NULL);
     assert_true(ret == 0);
     assert_non_null(mod);
     assert_true(m_mod_is(mod, M_MOD_IDLE));
@@ -25,7 +23,7 @@ void test_evt_ref(void **state) {
     m_mod_start(mod);
     m_mod_ps_tell(mod, mod, "Hello World", 0);
     
-    m_ctx_loop(test_ctx);
+    m_ctx_loop();
     
     /* Test that ref event is not nil */
     assert_non_null(ref);
@@ -42,7 +40,7 @@ static void my_recv(m_mod_t *mod, const m_queue_t *const evts) {
         if (msg->type == M_SRC_TYPE_PS) {
 
             ref = m_mem_ref((void *)msg);
-            m_ctx_quit(test_ctx,0);
+            m_ctx_quit(0);
         }
     });
 }

--- a/tests/test_mod.c
+++ b/tests/test_mod.c
@@ -27,14 +27,6 @@ void test_mod_register_NULL_name(void **state) {
     assert_null(test_mod);
 }
 
-void test_mod_register_NULL_hook(void **state) {
-    (void) state; /* unused */
-    
-    int ret = m_mod_register("testName", &test_mod, NULL, 0, NULL);
-    assert_false(ret == 0);
-    assert_null(test_mod);
-}
-
 void test_mod_register(void **state) {
     (void) state; /* unused */
     

--- a/tests/test_mod.c
+++ b/tests/test_mod.c
@@ -329,21 +329,21 @@ void test_mod_subscribe(void **state) {
 void test_mod_ref_NULL_name(void **state) {
     (void) state; /* unused */
     
-    testRef = m_mod_ref(test_mod, NULL);
+    testRef = m_mod_lookup(test_mod, NULL);
     assert_null(testRef);
 }
 
 void test_mod_ref_unexhistent_name(void **state) {
     (void) state; /* unused */
     
-    testRef = m_mod_ref(test_mod, "testName2");
+    testRef = m_mod_lookup(test_mod, "testName2");
     assert_null(testRef);
 }
 
 void test_mod_ref(void **state) {
     (void) state; /* unused */
     
-    testRef = m_mod_ref(test_mod, "testName");
+    testRef = m_mod_lookup(test_mod, "testName");
     assert_non_null(testRef);
 }
 
@@ -357,6 +357,7 @@ void test_mod_unref_NULL_ref(void **state) {
 void test_mod_unref(void **state) {
     (void) state; /* unused */
     
+    testRef = m_mem_ref(testRef);
     testRef = m_mem_unref(testRef);
     assert_null(testRef);
 }

--- a/tests/test_mod.c
+++ b/tests/test_mod.c
@@ -22,7 +22,7 @@ void test_mod_register_NULL_name(void **state) {
     (void) state; /* unused */
 
     m_mod_hook_t hook = { .on_evt = mod_recv };
-    int ret = m_mod_register(NULL, test_ctx, &test_mod, &hook, 0, NULL);
+    int ret = m_mod_register(NULL, &test_mod, &hook, 0, NULL);
     assert_false(ret == 0);
     assert_null(test_mod);
 }
@@ -30,7 +30,7 @@ void test_mod_register_NULL_name(void **state) {
 void test_mod_register_NULL_hook(void **state) {
     (void) state; /* unused */
     
-    int ret = m_mod_register("testName", test_ctx, &test_mod, NULL, 0, NULL);
+    int ret = m_mod_register("testName", &test_mod, NULL, 0, NULL);
     assert_false(ret == 0);
     assert_null(test_mod);
 }
@@ -39,7 +39,7 @@ void test_mod_register(void **state) {
     (void) state; /* unused */
     
     m_mod_hook_t hook = { .on_evt = mod_recv };
-    int ret = m_mod_register("testName", test_ctx, &test_mod, &hook, 0, NULL);
+    int ret = m_mod_register("testName", &test_mod, &hook, 0, NULL);
     assert_true(ret == 0);
     assert_non_null(test_mod);
     assert_true(m_mod_is(test_mod, M_MOD_IDLE));
@@ -49,7 +49,7 @@ void test_mod_register_already_registered(void **state) {
     (void) state; /* unused */
     
     m_mod_hook_t hook = { .on_evt = mod_recv };
-    int ret = m_mod_register("testName", test_ctx, &test_mod, &hook, 0, NULL);
+    int ret = m_mod_register("testName", &test_mod, &hook, 0, NULL);
     assert_false(ret == 0);
     assert_non_null(test_mod);
     assert_true(m_mod_is(test_mod, M_MOD_IDLE));
@@ -61,7 +61,7 @@ void test_mod_register_same_name(void **state) {
     m_mod_t *self2 = NULL;
     
     m_mod_hook_t hook = { .on_evt = mod_recv };
-    int ret = m_mod_register("testName", test_ctx, &self2, &hook, 0, NULL);
+    int ret = m_mod_register("testName", &self2, &hook, 0, NULL);
     assert_false(ret == 0);
     assert_null(self2);
 }
@@ -93,7 +93,7 @@ void test_mod_false_init(void **state) {
     (void) state; /* unused */
     
     m_mod_hook_t hook = { .on_start = init_false, .on_evt = mod_recv };
-    int ret = m_mod_register("testName", test_ctx, &test_mod, &hook, 0, NULL);
+    int ret = m_mod_register("testName", &test_mod, &hook, 0, NULL);
     assert_true(ret == 0);
     assert_non_null(test_mod);
     assert_true(m_mod_is(test_mod, M_MOD_IDLE));
@@ -467,7 +467,7 @@ static void mod_recv_ready(m_mod_t *mod, const m_queue_t *const evts) {
         if (msg->type == M_SRC_TYPE_PS) {
             ctr--;
             if (!strcmp((char *) msg->ps_evt->data, "hi3!")) {
-                m_ctx_quit(test_ctx, ctr);
+                m_ctx_quit(ctr);
             }
         }
     });

--- a/tests/test_mod.h
+++ b/tests/test_mod.h
@@ -1,7 +1,6 @@
 #include "test_commons.h"
 
 void test_mod_register_NULL_name(void **state);
-void test_mod_register_NULL_hook(void **state);
 void test_mod_register(void **state);
 void test_mod_register_already_registered(void **state);
 void test_mod_register_same_name(void **state);

--- a/tests/test_perf.c
+++ b/tests/test_perf.c
@@ -13,17 +13,14 @@ static int ctr;
 void test_poll_perf(void **state) {
     (void) state; /* unused */
 
-    test_ctx = NULL;
-
-    int ret = m_ctx_register("perf", &test_ctx, 0, NULL);
+    int ret = m_ctx_register("perf", 0, NULL);
     assert_true(ret == 0);
-    assert_non_null(test_ctx);
 
     m_src_thresh_t thresh = { .activity_freq = 10.0 };
     m_src_thresh_t alarm = {0};
         
     m_mod_hook_t hook = { .on_evt = my_recv };
-    ret = m_mod_register("testName", test_ctx, &mod, &hook, 0, NULL);
+    ret = m_mod_register("testName", &mod, &hook, 0, NULL);
     assert_true(ret == 0);
     assert_non_null(mod);
     assert_true(m_mod_is(mod, M_MOD_IDLE));
@@ -48,7 +45,7 @@ void test_poll_perf(void **state) {
     double time_spent = (double)(end_tell - begin_tell);
     printf("Messages feeding took %.2lf us\n", time_spent);
     
-    m_ctx_loop(test_ctx);
+    m_ctx_loop();
     
     clock_t end_recv = clock();
     time_spent = (double)(end_recv - end_tell);
@@ -65,7 +62,7 @@ static void my_recv(m_mod_t *mod, const m_queue_t *const evts) {
     m_itr_foreach(evts, {
         m_evt_t *msg = m_itr_get(m_itr);
         if (msg->type == M_SRC_TYPE_PS && ++ctr == MAX_LEN) {
-            m_ctx_quit(test_ctx, 0);
+            m_ctx_quit(0);
         } else if (msg->type == M_SRC_TYPE_THRESH) {
             m_src_thresh_t *alarm = (m_src_thresh_t *)msg->userdata;
             alarm->activity_freq = msg->thresh_evt->activity_freq;


### PR DESCRIPTION


<!-- readthedocs-preview libmodule start -->
----
:books: Documentation preview :books:: https://libmodule--18.org.readthedocs.build/en/18/

<!-- readthedocs-preview libmodule end -->